### PR TITLE
Fix/assembly method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Cargo.lock
 *__*.csv
 .tmp*.dot
 .tmp*.csv
+MANIFEST.in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rogtk"
-version = "0.1.13"
+version = "0.1.14dev"
 authors = [
   "Pedro Olivares Chauvet <pedro.olivares@mdc-berlin.de>", 
   "Pedro Olivares Chauvet <pedro.olivares@weizmann.ac.il>", 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rogtk"
-version = "0.1.14dev"
+version = "0.1.14-dev"
 authors = [
   "Pedro Olivares Chauvet <pedro.olivares@mdc-berlin.de>", 
   "Pedro Olivares Chauvet <pedro.olivares@weizmann.ac.il>", 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "maturin"
 
 [project]
 name = "rogtk"
-version = "0.1.13"
+version = "0.1.14dev"
 requires-python = ">=3.10"
 dependencies = [
     "polars>=1.25,!=1.26.*"

--- a/src/djfind.rs
+++ b/src/djfind.rs
@@ -131,10 +131,12 @@ fn find_anchor_nodes(
     
     for node_idx in graph.node_indices() {
         let sequence = &graph[node_idx];
-        if sequence.contains(start_seq) {
+        if sequence.starts_with(start_seq) {
+            debug!("Found start node idx {} {}", node_idx.index(), &graph[node_idx]);
             start_nodes.push(node_idx);
         }
-        if sequence.contains(end_seq) {
+        if sequence.ends_with(end_seq) {
+            debug!("Found end node idx {} {}", node_idx.index(), &graph[node_idx]);
             end_nodes.push(node_idx);
         }
     }

--- a/src/djfind.rs
+++ b/src/djfind.rs
@@ -23,40 +23,36 @@ pub enum AssemblyMethod {
     ShortestPath {
         start_anchor: String,
         end_anchor: String,
-    }
+    },
+    ShortestPathAuto,
+
 }
 
 impl AssemblyMethod {
-    /// Parse a method string and optional anchors into an AssemblyMethod
-    pub fn from_str(method: &str, start_anchor: Option<String>, end_anchor: Option<String>) 
-        -> Result<Self, String> {
+    pub fn from_str(method: &str, start_anchor: Option<String>, end_anchor: Option<String>) -> Result<Self, String> {
         match method {
             "compression" => {
-                // For compression method, anchors should not be provided
                 if start_anchor.is_some() || end_anchor.is_some() {
                     return Err("Anchor sequences should not be provided for compression method".to_string());
                 }
                 Ok(AssemblyMethod::Compression)
             },
             "shortest_path" => {
-                // For shortest path, both anchors must be provided
                 match (start_anchor, end_anchor) {
                     (Some(start), Some(end)) => Ok(AssemblyMethod::ShortestPath { 
                         start_anchor: start, 
                         end_anchor: end 
                     }),
-                    (None, None) => {
-                        Err("Both start_anchor and end_anchor are required for shortest_path method".to_string())
-                    },
-                    (None, Some(_)) => {
-                        Err("start_anchor is required for shortest_path method".to_string())
-                    },
-                    (Some(_), None) => {
-                        Err("end_anchor is required for shortest_path method".to_string())
-                    }
+                    _ => Err("Both start_anchor and end_anchor are required for shortest_path method".to_string()),
                 }
             },
-            _ => Err("Invalid assembly method. Must be 'compression' or 'shortest_path'".to_string())
+            "shortest_path_auto" => {
+                if start_anchor.is_some() || end_anchor.is_some() {
+                    return Err("Anchor sequences should not be provided for shortest_path_auto method".to_string());
+                }
+                Ok(AssemblyMethod::ShortestPathAuto)
+            },
+            _ => Err(format!("Unknown assembly method: {}", method)),
         }
     }
 }

--- a/src/djfind.rs
+++ b/src/djfind.rs
@@ -246,22 +246,22 @@ pub fn assemble_with_path_finding<K: Kmer + Send + Sync + Debug + 'static>(
 ) -> Result<PathFindingResult, String> {
     let _ = env_logger::try_init();
     info!("Converting de Bruijn graph to weighted digraph for path finding");
-    
+
     // Convert to petgraph
     let (pg, _node_map) = convert_to_petgraph(preliminary_graph);
-    
+
     // Find anchor nodes
     let (start_nodes, end_nodes) = find_anchor_nodes(&pg, start_anchor, end_anchor);
-    
+
     if start_nodes.is_empty() {
         return Err(format!("No nodes containing start anchor '{}' found", start_anchor));
     }
     if end_nodes.is_empty() {
         return Err(format!("No nodes containing end anchor '{}' found", end_anchor));
     }
-    
+
     info!("Found {} start nodes and {} end nodes", start_nodes.len(), end_nodes.len());
-    
+
     // Find shortest path
     if let Some((path, total_weight)) = find_shortest_path(&pg, &start_nodes, &end_nodes) {
         let sequences = extract_path_sequences(&pg, &path);
@@ -270,12 +270,12 @@ pub fn assemble_with_path_finding<K: Kmer + Send + Sync + Debug + 'static>(
         let assembled_sequence = concatenate_path_sequences(&sequences, K::k());
 
         info!("Found path with total weight {} and mean coverage {}", 
-              total_weight, mean_coverage);
+            total_weight, mean_coverage);
 
         info!("Assembled sequence length: {}", assembled_sequence.len());
         warn!("Assembled sequence : {}", assembled_sequence);
 
-        
+
         Ok(PathFindingResult {
             path: sequences,
             total_weight,
@@ -287,4 +287,191 @@ pub fn assemble_with_path_finding<K: Kmer + Send + Sync + Debug + 'static>(
         Err("No valid path found between anchors".to_string())
     }
 }
+// Add this function to djfind.rs for automatic endpoint detection and path finding
 
+/// Find candidate endpoints based on in/out degree analysis
+/// Returns (start_candidates, end_candidates)
+fn find_endpoint_candidates<K: Kmer>(
+    graph: &DebruijnGraph<K, u16>,
+) -> (Vec<usize>, Vec<usize>) {
+    let mut start_candidates = Vec::new();
+    let mut end_candidates = Vec::new();
+    
+    // Calculate average coverage for filtering
+    let mut coverages = Vec::new();
+    for node_id in 0..graph.len() {
+        let node = graph.get_node(node_id);
+        coverages.push(*node.data());
+    }
+    
+    let avg_coverage = coverages.iter().map(|&c| c as f64).sum::<f64>() / coverages.len() as f64;
+    let min_coverage_threshold = (avg_coverage * 0.1).max(1.0) as u16;
+    
+    info!("Average coverage: {:.2}, min threshold: {}", avg_coverage, min_coverage_threshold);
+    
+    for node_id in 0..graph.len() {
+        let node = graph.get_node(node_id);
+        let coverage = *node.data();
+        
+        // Skip very low coverage nodes (likely errors)
+        if coverage < min_coverage_threshold {
+            continue;
+        }
+        
+        // Count in-edges and out-edges separately
+        let in_degree = node.l_edges().len();
+        let out_degree = node.r_edges().len();
+        
+        debug!("Node {:?}: coverage={}, in={}, out={}", 
+               node.sequence(), coverage, in_degree, out_degree);
+        
+        // Start candidates: no incoming edges (or very few compared to outgoing)
+        if in_degree == 0 && out_degree > 0 {
+            start_candidates.push(node_id);
+            info!("Start candidate found: {:?} (coverage={})", node.sequence(), coverage);
+        }
+        
+        // End candidates: no outgoing edges (or very few compared to incoming)
+        if out_degree == 0 && in_degree > 0 {
+            end_candidates.push(node_id);
+            info!("End candidate found: {:?} (coverage={})", node.sequence(), coverage);
+        }
+    }
+    
+    (start_candidates, end_candidates)
+}
+
+/// Score a path based on multiple metrics
+fn score_path(
+    graph: &DiGraph<String, f64>,
+    path: &[NodeIndex],
+    total_weight: f64,
+) -> f64 {
+    if path.is_empty() {
+        return 0.0;
+    }
+    
+    // Calculate path length
+    let path_length = path.iter()
+        .map(|&idx| graph[idx].len())
+        .sum::<usize>() as f64;
+    
+    // Calculate mean coverage (inverse of weight)
+    let mean_coverage = 1.0 / (total_weight / path.len() as f64);
+    
+    // Simple scoring: prioritize length and coverage equally
+    // Normalize length by expected amplicon size (5000bp)
+    let normalized_length = (path_length / 5000.0).min(1.0);
+    let normalized_coverage = (mean_coverage / 100.0).min(1.0);
+    
+    let score = 0.6 * normalized_length + 0.4 * normalized_coverage;
+    
+    debug!("Path score: {:.3} (len={:.0}, cov={:.1})", 
+           score, path_length, mean_coverage);
+    
+    score
+}
+
+/// Find best path among multiple endpoint pairs
+fn find_best_endpoint_pair<K: Kmer + Send + Sync + Debug + 'static>(
+    graph: &DebruijnGraph<K, u16>,
+    start_candidates: Vec<usize>,
+    end_candidates: Vec<usize>,
+) -> Result<PathFindingResult, String> {
+    info!("Evaluating {} start x {} end candidate pairs", 
+         start_candidates.len(), end_candidates.len());
+    
+    // Convert to petgraph once
+    let (pg, _) = convert_to_petgraph(graph);
+    
+    // Limit number of pairs to evaluate
+    const MAX_PAIRS: usize = 100;
+    let mut evaluated_pairs = 0;
+    
+    let mut best_result: Option<(PathFindingResult, f64)> = None;
+    
+    for &start_id in &start_candidates {
+        for &end_id in &end_candidates {
+            if evaluated_pairs >= MAX_PAIRS {
+                warn!("Reached maximum pairs limit ({})", MAX_PAIRS);
+                break;
+            }
+            evaluated_pairs += 1;
+            
+            let start_seq = graph.get_node(start_id).sequence().to_string();
+            let end_seq = graph.get_node(end_id).sequence().to_string();
+            
+            debug!("Evaluating path: {} -> {}", start_seq, end_seq);
+            
+            // Find nodes in petgraph
+            let start_nodes: Vec<NodeIndex> = pg.node_indices()
+                .filter(|&idx| pg[idx].contains(&start_seq))
+                .collect();
+            let end_nodes: Vec<NodeIndex> = pg.node_indices()
+                .filter(|&idx| pg[idx].contains(&end_seq))
+                .collect();
+            
+            if start_nodes.is_empty() || end_nodes.is_empty() {
+                continue;
+            }
+            
+            // Try to find path
+            if let Some((path, total_weight)) = find_shortest_path(&pg, &start_nodes, &end_nodes) {
+                let score = score_path(&pg, &path, total_weight);
+                
+                info!("Found path with score {:.3}", score);
+                
+                if best_result.is_none() || score > best_result.as_ref().unwrap().1 {
+                    let sequences = extract_path_sequences(&pg, &path);
+                    let mean_coverage = 1.0 / (total_weight / path.len() as f64);
+                    let assembled_sequence = concatenate_path_sequences(&sequences, K::k());
+                    
+                    best_result = Some((PathFindingResult {
+                        path: sequences,
+                        total_weight,
+                        mean_coverage,
+                        assembled_sequence,
+                    }, score));
+                }
+            }
+        }
+    }
+    
+    match best_result {
+        Some((result, score)) => {
+            info!("Selected best path with score {:.3}, length {}", 
+                  score, result.assembled_sequence.len());
+            Ok(result)
+        }
+        None => Err("No valid paths found between any endpoint pairs".to_string())
+    }
+}
+
+/// Main entry point for automatic path-based assembly
+pub fn assemble_with_auto_path_finding<K: Kmer + Send + Sync + Debug + 'static>(
+    preliminary_graph: &DebruijnGraph<K, u16>,
+) -> Result<PathFindingResult, String> {
+    let _ = env_logger::try_init();
+    info!("Starting automatic path finding assembly");
+    
+    // Find endpoint candidates
+    let (start_candidates, end_candidates) = find_endpoint_candidates(preliminary_graph);
+    
+    match (start_candidates.len(), end_candidates.len()) {
+        (0, _) => Err("No start candidates found - possibly circular or highly branched".to_string()),
+        (_, 0) => Err("No end candidates found - possibly circular or highly branched".to_string()),
+        (1, 1) => {
+            // Ideal case - single path
+            info!("Found exactly one start and one end candidate");
+            let start_seq = preliminary_graph.get_node(start_candidates[0]).sequence().to_string();
+            let end_seq = preliminary_graph.get_node(end_candidates[0]).sequence().to_string();
+            assemble_with_path_finding(preliminary_graph, &start_seq, &end_seq)
+        },
+        _ => {
+            // Multiple candidates - need to evaluate
+            info!("Found {} start and {} end candidates", 
+                  start_candidates.len(), end_candidates.len());
+            find_best_endpoint_pair(preliminary_graph, start_candidates, end_candidates)
+        }
+    }
+}

--- a/src/expressions.rs
+++ b/src/expressions.rs
@@ -255,30 +255,15 @@ fn output_string_type(input_fields: &[Field]) -> PolarsResult<Field> {
 #[polars_expr(output_type_func=output_string_type)]
 fn assemble_sequences_expr(inputs: &[Series], kwargs: AssemblyKwargs) -> PolarsResult<Series> {
     debug!("Received kwargs: {:?}", kwargs);
-
-    // Create AssemblyMethod based on method string
-    let method = match kwargs.method.as_str() {
-        "compression" => Ok(AssemblyMethod::Compression),
-        "shortest_path" => AssemblyMethod::from_str(
-            &kwargs.method,
-            kwargs.start_anchor,
-            kwargs.end_anchor,
-        ),
-        _ => Err("Invalid assembly method. Must be 'compression' or 'shortest_path'".to_string())
-    };
-
-    // Handle any errors from method parsing
-    let method = match method {
-        Ok(m) => m,
-        Err(e) => {
-            debug!("Method parsing error: {}", e);
-            return Ok(StringChunked::from_slice(
-                PlSmallStr::from_str("assembled_sequences"),
-                &[""]
-            ).into_series());
-        }
-    };
-
+    
+    let method = AssemblyMethod::from_str(
+        &kwargs.method,
+        kwargs.start_anchor,
+        kwargs.end_anchor,
+    ).map_err(|e| PolarsError::ComputeError(
+        format!("Invalid assembly method: {}", e).into()
+    ))?;
+    
     // Extract sequences from input series
     let ca = inputs[0].str()?;
     
@@ -289,7 +274,7 @@ fn assemble_sequences_expr(inputs: &[Series], kwargs: AssemblyKwargs) -> PolarsR
         .collect();
     
     // Call assembly function with only_largest always set to true
-    match assemble_sequences(
+    let contigs = assemble_sequences(
         sequences,
         kwargs.k,
         kwargs.min_coverage,
@@ -299,22 +284,15 @@ fn assemble_sequences_expr(inputs: &[Series], kwargs: AssemblyKwargs) -> PolarsR
         kwargs.min_length,
         kwargs.auto_k,
         kwargs.prefix,
-    ) {
-        Ok(contigs) => {
-            let result = contigs.join("\n");
-            Ok(StringChunked::from_slice(
-                    PlSmallStr::from_str("assembled_sequences"),
-                    &[result.as_str()]
-            ).into_series())
-        },
-        Err(e) => {
-            debug!("Assembly failed: {}", e);
-            Ok(StringChunked::from_slice(
-                    PlSmallStr::from_str("assembled_sequences"),
-                    &[""]
-            ).into_series())
-        }
-    }
+    ).map_err(|e| PolarsError::ComputeError(
+        format!("Assembly failed: {}", e).into()
+    ))?;
+
+    let result = contigs.join("\n");
+    Ok(StringChunked::from_slice(
+        PlSmallStr::from_str("assembled_sequences"),
+        &[result.as_str()]
+    ).into_series())
 }
 
 #[derive(Deserialize)]

--- a/src/graph_viz.rs
+++ b/src/graph_viz.rs
@@ -145,14 +145,13 @@ fn export_dot_from_dataframe(
         let edges = outgoing_nodes.get(idx).unwrap_or("");
         let directions = outgoing_directions.get(idx).unwrap_or("");
         
-        // Write node
         let color = match node_type {
             "isolated" | "terminal" => "#ff110030",
             _ => "#4895fa30"
         };
         
         writeln!(file,
-            "    n{} [label=\"ID: {}\\nSeq: {}\\ncov: {}\" style=filled fillcolor=\"{}\"]",
+            "    n{} [label=\"ID: {}\\nSeq: {}\\ncov: {}\", style=filled, fillcolor=\"{}\"]",
             node_id, node_id, sequence, node_data, color
         )?;
         


### PR DESCRIPTION
Implemented shortest path auto but needs testing. This functionality will be placed on hold since new strategies need to be designed for the parsing of PRtracer cassettes. The current limitation of kmer size = 64 bp (see below) disqualifies the Debruijn Graph assembly in its current form. 

TODO:
 - The python interface for plugging auto shortest path is missing

---
KMER SIZE LIMITATIONS IN ROGTK
===============================

Current Maximum: 64 bp
----------------------
The codebase currently has a hard-coded maximum kmer size of 64 base pairs.

Technical Details
-----------------
1. **Implementation Location**: src/fracture.rs
   - Lines 251-253: Main kmer type selection
   - Lines 286-287, 315-317: Additional validation checks
   - Error messages explicitly state "maximum is 64"

2. **Kmer Type Hierarchy**:
   - Kmer4: for k ≤ 4
   - Kmer8: for k ≤ 8
   - Kmer16: for k ≤ 16
   - Kmer32: for k ≤ 32
   - Kmer64: for k ≤ 64

3. **Library Dependency**: 
   - Uses debruijn crate v0.3.4
   - This library only provides kmer types up to Kmer64

4. **Technical Constraint**:
   - Kmers are stored using bit-packed representation
   - Each nucleotide requires 2 bits (A, C, G, T)
   - 64-bit integers are the largest standard type used
   - This allows efficient storage and manipulation

5. **Auto-estimation**:
   - The estimate_k() function clamps k between 11 and 63
   - Formula: k = mean_read_length / 3 (rounded to odd number)

Why the Limitation Exists
-------------------------
- Performance: 64-bit operations are highly optimized on modern CPUs
- Memory efficiency: Compact representation using native integer types
- Library constraint: The debruijn crate doesn't support larger kmers

Expanding Beyond 64 bp
----------------------
To support kmers > 64 bp would require:

1. **Different kmer library** that supports 128-bit integers or arbitrary sizes
2. **Custom implementation** using multiple integers to represent longer kmers
3. **Code modifications**:
   - Update all match statements in fracture.rs
   - Modify type selection logic
   - Update validation checks
   - Potentially impact performance

4. **Alternative approaches**:
   - Some bioinformatics tools use string-based representations for very long kmers
   - Trade-off between performance and maximum kmer size
   - Consider whether kmers > 64 are actually needed for the specific use case

Current Behavior
----------------
When k > 64 is requested:
- Error message is logged
- Empty vector of contigs is returned
- Assembly process continues but produces no results
